### PR TITLE
フッターの追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import axios from "axios";
 import Blog from "./components/Blog";
 import Header from "./components/Header";
+import Footer from "./components/Footer";
 
 function App() {
   const [count, setCount] = useState(0);
@@ -38,6 +39,7 @@ function App() {
           <Blog post={item} />
         ))}
       </div>
+      <Footer />
     </>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+function Footer() {
+  return (
+    <>
+      <div className="mt-20 bg-black w-full">
+        <ul className="flex text-white p-5 gap-12 place-content-center">
+          <li>お問い合わせ</li>
+          <li>プライバシーポリシー</li>
+          <li>運営者情報</li>
+        </ul>
+        <p className=" text-white p-5 text-center">
+          2024 SUZUKAZINE All Rights Reserved
+        </p>
+      </div>
+    </>
+  );
+}
+
+export default Footer;


### PR DESCRIPTION
## 概要
TOPページにフッターを追加した。カテゴリーや関連外部サイトリンクは追加せず、お問い合わせ・プライバシーポリシー・運営者情報の固定ページのみ。

## 備考
投稿リストのスタイルが崩れており、投稿カードとフッターと重なってしまっていたため、`mt-20`を追加して重なりを一時的に避難している。投稿リストのスタイルを正常化した時には、この`mt-20`は削除すること。