### PR TITLE
詳細ページの追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "axios": "^1.7.2",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.25.1"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
@@ -678,6 +679,14 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.18.0.tgz",
+      "integrity": "sha512-L3jkqmqoSVBVKHfpGZmLrex0lxR5SucGA0sUfFzGctehw+S/ggL9L/0NnC5mw6P8HUWpFZ3nQw3cRApjjWx9Sw==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3177,6 +3186,36 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.25.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.25.1.tgz",
+      "integrity": "sha512-u8ELFr5Z6g02nUtpPAggP73Jigj1mRePSwhS/2nkTrlPU5yEkH1vYzWNyvSnSzeeE2DNqWdH+P8OhIh9wuXhTw==",
+      "dependencies": {
+        "@remix-run/router": "1.18.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.25.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.25.1.tgz",
+      "integrity": "sha512-0tUDpbFvk35iv+N89dWNrJp+afLgd+y4VtorJZuOCXK0kkCWjEvb3vTJM++SYvMEpbVwXKf3FjeVveVEb6JpDQ==",
+      "dependencies": {
+        "@remix-run/router": "1.18.0",
+        "react-router": "6.25.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-cache": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react-router-dom": "^6.25.1"
       },
       "devDependencies": {
+        "@tailwindcss/typography": "^0.5.13",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.15.0",
@@ -1108,6 +1109,34 @@
       "dev": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.13.tgz",
+      "integrity": "sha512-ADGcJ8dX21dVVHIwTRgzrcunY6YY9uSlAHHGVKvkA+vLc5qLwEszvKts40lx7z0qc4clpjclwLeK5rVCV2P/uw==",
+      "dev": true,
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@types/estree": {
@@ -2627,6 +2656,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "axios": "^1.7.2",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.25.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-router-dom": "^6.25.1"
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.13",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^7.15.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,19 @@
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Header from "./components/Header";
-import Post from "./components/Post";
 import Footer from "./components/Footer";
+import Post from "./components/Post";
+import PostDetail from "./components/PostDetail";
 
 function App() {
   return (
-    <>
+    <Router>
       <Header />
-      <Post />
+      <Routes>
+        <Route path="/" element={<Post />} />
+        <Route path="/post/:id" element={<PostDetail />} />
+      </Routes>
       <Footer />
-    </>
+    </Router>
   );
 }
 

--- a/src/components/Blog.tsx
+++ b/src/components/Blog.tsx
@@ -1,8 +1,10 @@
+import { Link } from "react-router-dom";
 import axios from "axios";
 import { useState, useEffect } from "react";
 import "./Blog.css";
 
 interface Post {
+  id: number;
   title: {
     rendered: string;
   };
@@ -38,19 +40,21 @@ export default function Blog({ post }: BlogProps) {
   return (
     <div className="container">
       <div className="blog-container">
-        <p className="blog-date">
-          {new Date(Date.now()).toLocaleDateString("en-US", {
-            day: "numeric",
-            month: "long",
-            year: "numeric",
-          })}
-        </p>
-        <h2 className="blog-title">{post.title.rendered}</h2>
-        <p
-          className="blog-excerpt"
-          dangerouslySetInnerHTML={{ __html: post.excerpt.rendered }}
-        />
-        <img src={featuredImage} className="mask" />
+        <Link to={`/post/${post.id}`}>
+          <p className="blog-date">
+            {new Date(Date.now()).toLocaleDateString("en-US", {
+              day: "numeric",
+              month: "long",
+              year: "numeric",
+            })}
+          </p>
+          <h2 className="blog-title">{post.title.rendered}</h2>
+          <p
+            className="blog-excerpt"
+            dangerouslySetInnerHTML={{ __html: post.excerpt.rendered }}
+          />
+          <img src={featuredImage} className="mask" />
+        </Link>
       </div>
     </div>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 function Footer() {
   return (
     <>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 function Header() {
   return (
     <>

--- a/src/components/PostDetail.tsx
+++ b/src/components/PostDetail.tsx
@@ -43,14 +43,33 @@ function PostDetail() {
   }, [id]);
 
   if (!post) {
-    return <div>Loading...</div>;
+    return (
+      <div className="flex justify-center items-center h-screen text-lg">
+        Loading...
+      </div>
+    );
   }
 
   return (
-    <div className="post-detail">
-      <h1>{post.title.rendered}</h1>
-      {featuredImage && <img src={featuredImage} alt={post.title.rendered} />}
-      <div dangerouslySetInnerHTML={{ __html: post.content.rendered }} />
+    <div className="container mx-auto p-4">
+      <div className="bg-white shadow-md rounded-lg overflow-hidden">
+        <div className="p-6">
+          <h1 className="text-4xl font-bold mb-4 border-b-4 border-gray-400 pb-2">
+            {post.title.rendered}
+          </h1>
+          {featuredImage && (
+            <img
+              src={featuredImage}
+              alt={post.title.rendered}
+              className="w-full h-auto mb-4 rounded-lg"
+            />
+          )}
+          <div
+            className="prose prose-lg max-w-none"
+            dangerouslySetInnerHTML={{ __html: post.content.rendered }}
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/PostDetail.tsx
+++ b/src/components/PostDetail.tsx
@@ -1,0 +1,58 @@
+import { useParams } from "react-router-dom";
+import { useState, useEffect } from "react";
+import axios from "axios";
+
+interface Post {
+  title: {
+    rendered: string;
+  };
+  content: {
+    rendered: string;
+  };
+  _links: {
+    ["wp:featuredmedia"]: [
+      {
+        href: string;
+      }
+    ];
+  };
+}
+
+function PostDetail() {
+  const { id } = useParams<{ id: string }>();
+  const [post, setPost] = useState<Post | null>(null);
+  const [featuredImage, setFeaturedImage] = useState<string | undefined>();
+
+  const fetchPost = () => {
+    axios
+      .get(`http://suzukazine.local/wp-json/wp/v2/posts/${id}`)
+      .then((res) => {
+        setPost(res.data);
+        if (res.data._links["wp:featuredmedia"]) {
+          axios
+            .get(res.data._links["wp:featuredmedia"][0].href)
+            .then((response) => {
+              setFeaturedImage(response.data.source_url);
+            });
+        }
+      });
+  };
+
+  useEffect(() => {
+    fetchPost();
+  }, [id]);
+
+  if (!post) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div className="post-detail">
+      <h1>{post.title.rendered}</h1>
+      {featuredImage && <img src={featuredImage} alt={post.title.rendered} />}
+      <div dangerouslySetInnerHTML={{ __html: post.content.rendered }} />
+    </div>
+  );
+}
+
+export default PostDetail;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,5 +4,5 @@ export default {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [require("@tailwindcss/typography")],
 };


### PR DESCRIPTION
## 概要
記事の一覧ページから記事の詳細ページにアクセスできるようにする。

## タスク
close #3 

## 学び
* Reactで作成したSPAにUIとURLを紐づけるには、react-router-domを使う
* Tailwind CSS の proseクラスで記事の見た目を簡単に整えられる。