### PR TITLE
カテゴリーページの実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import PostDetail from "./components/PostDetail";
 import ContactPage from "./components/ContactPage";
 import PrivacyPolicy from "./components/PrivacyPolicy";
 import Profile from "./components/Profile";
+import Category from "./components/Category"; // 修正されたインポート
 
 function App() {
   return (
@@ -15,8 +16,9 @@ function App() {
         <Route path="/" element={<Post />} />
         <Route path="/post/:id" element={<PostDetail />} />
         <Route path="/contact" element={<ContactPage />} />
-        <Route path="/privacy-policy" element={<PrivacyPolicy />} />{" "}
-        <Route path="/profile" element={<Profile />} />{" "}
+        <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+        <Route path="/profile" element={<Profile />} />
+        <Route path="/category/:categoryName" element={<Category />} />{" "}
       </Routes>
       <Footer />
     </Router>

--- a/src/components/Blog.tsx
+++ b/src/components/Blog.tsx
@@ -25,24 +25,26 @@ interface BlogProps {
 }
 
 export default function Blog({ post }: BlogProps) {
-  const [featuredImage, setFeaturedimage] = useState<string | undefined>();
+  const [featuredImage, setFeaturedImage] = useState<string | undefined>();
 
   const getImage = () => {
-    axios.get(post?._links["wp:featuredmedia"][0]?.href).then((response) => {
-      setFeaturedimage(response.data.source_url);
-    });
+    if (post._links["wp:featuredmedia"]) {
+      axios.get(post._links["wp:featuredmedia"][0].href).then((response) => {
+        setFeaturedImage(response.data.source_url);
+      });
+    }
   };
 
   useEffect(() => {
     getImage();
-  }, []);
+  }, [post]);
 
   return (
     <div className="container">
       <div className="blog-container">
         <Link to={`/post/${post.id}`}>
           <p className="blog-date">
-            {new Date(Date.now()).toLocaleDateString("en-US", {
+            {new Date(post.date).toLocaleDateString("ja-JP", {
               day: "numeric",
               month: "long",
               year: "numeric",
@@ -53,7 +55,13 @@ export default function Blog({ post }: BlogProps) {
             className="blog-excerpt"
             dangerouslySetInnerHTML={{ __html: post.excerpt.rendered }}
           />
-          <img src={featuredImage} className="mask" />
+          {featuredImage && (
+            <img
+              src={featuredImage}
+              className="mask"
+              alt={post.title.rendered}
+            />
+          )}
         </Link>
       </div>
     </div>

--- a/src/components/Category.tsx
+++ b/src/components/Category.tsx
@@ -1,0 +1,61 @@
+import { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import axios from "axios";
+import Blog from "./Blog";
+
+interface Category {
+  id: number;
+  slug: string;
+  name: string;
+}
+
+function Category() {
+  const { categoryName } = useParams<{ categoryName: string }>();
+  const [posts, setPosts] = useState([]);
+  const [category, setCategory] = useState<Category | null>(null);
+
+  const fetchCategory = () => {
+    axios
+      .get(
+        `http://suzukazine.local/wp-json/wp/v2/categories?slug=${categoryName}`
+      )
+      .then((res) => {
+        if (res.data.length > 0) {
+          setCategory(res.data[0]);
+        }
+      });
+  };
+
+  const fetchPosts = (categoryId: number) => {
+    axios
+      .get(
+        `http://suzukazine.local/wp-json/wp/v2/posts?categories=${categoryId}`
+      )
+      .then((res) => {
+        setPosts(res.data);
+      });
+  };
+
+  useEffect(() => {
+    fetchCategory();
+  }, [categoryName]);
+
+  useEffect(() => {
+    if (category) {
+      fetchPosts(category.id);
+    }
+  }, [category]);
+
+  return (
+    <>
+      <h2 className="text-3xl font-bold my-5 text-center">{categoryName}</h2>
+      <div className="my-7">
+        {posts.map((item) => (
+          <Blog key={item.id} post={item} />
+        ))}
+      </div>
+    </>
+  );
+}
+
+export default Category;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,3 @@
-// components/Header.tsx
-
 import { Link } from "react-router-dom";
 
 function Header() {
@@ -12,13 +10,13 @@ function Header() {
             <Link to="/">ホーム</Link>
           </li>
           <li>
-            <Link to="/post/1">グルメ</Link>
+            <Link to="/category/グルメ">グルメ</Link>
           </li>
           <li>
-            <Link to="/post/2">生活</Link>
+            <Link to="/category/生活">生活</Link>
           </li>
           <li>
-            <Link to="/post/3">観光</Link>
+            <Link to="/category/観光">観光</Link>
           </li>
           <li>
             <Link to="/contact">お問い合わせ</Link>

--- a/src/index.php
+++ b/src/index.php
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo( 'charset' ); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <?php wp_head(); ?>
+    <link rel="stylesheet" href="<?php echo get_stylesheet_directory_uri(); ?>/dist/assets/index-CUEBLmWL.css">
+</head>
+<body <?php body_class(); ?>>
+    <div id="root"></div>
+    <?php wp_footer(); ?>
+    <script type="module" src="<?php echo get_stylesheet_directory_uri(); ?>/dist/assets/index-VppnZHJf.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## 概要
グルメ、生活、観光のカテゴリーページを追加。

## 該当イシュー
close #6 

## 備考
記事一覧が表示されず苦戦したが、その原因はパーマリンクが違ったからだった。